### PR TITLE
Hide vertical scrollbar on code blocks if content does not overflow

### DIFF
--- a/static/css/poison.css
+++ b/static/css/poison.css
@@ -206,7 +206,7 @@ h1, h2, h3, h4, h5, strong {
     white-space: pre;
 }
 div.highlight pre {
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 #page-nav {
     text-align: center;


### PR DESCRIPTION
Hello!

This change removes vertical scrollbars on code blocks when they are not needed