### PR TITLE
Fixed date issue on list pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ I recommend starting by copying/pasting the following code into your config.toml
 baseURL = "/"
 languageCode = "en-us"
 theme = "poison"
-paginate = 5
+paginate = 10
 pluralizelisttitles = false
 
 [params]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
                     <a href="{{ .RelPermalink }}">{{ .Title }}</a>
                 </span>
                 <span class="published">
-                    <time class="pull-right post-list">{{ .Date.Format "Jan 1, 2006" }}</time>
+                    <time class="pull-right post-list">{{ .Date | time.Format ":date_long" }}</time>
                 </span>
             </li>
         {{ end }}


### PR DESCRIPTION
For some reason, I had to format the dates differently on the list pages than on the single pages.  Not sure if I am just lacking knowledge or if this is some kind of Hugo bug, but either way I was able to fix it by formatting my dates with:

`.Date | time.Format ":date_long"`

instead of:

`.Date.Format "January 1, 2006"`