### PR TITLE
Issue 21 katex causing display issues

### DIFF
--- a/static/js/katex.js
+++ b/static/js/katex.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", function() {
 
     // provides an escape for dollar sign chars if KaTeX is not desired
-    document.body.innerHTML = document.body.innerHTML.replace(/\$/g, '<span>$</span>');
+    document.body.innerHTML = document.body.innerHTML.replace(/\\\$/g, '<span>$</span>');
 
     renderMathInElement(document.body, {
         delimiters: [

--- a/static/js/katex.js
+++ b/static/js/katex.js
@@ -1,4 +1,8 @@
 document.addEventListener("DOMContentLoaded", function() {
+
+    // provides an escape for dollar sign chars if KaTeX is not desired
+    document.body.innerHTML = document.body.innerHTML.replace(/\$/g, '<span>$</span>');
+
     renderMathInElement(document.body, {
         delimiters: [
             {left: "$$", right: "$$", display: true},


### PR DESCRIPTION
I added a line of JavaScript that fixes the issue. It replaces all instances of `\\$` with `<span>$</span>`. So going forward,  KaTeX can be escaped by putting a double backslash in front of dollar signs (like `\\$`) to represent a normal dollar sign.