### PR TITLE
Varaible out the code colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ pluralizelisttitles = false   # removes the automatically appended "s" on sideba
     date_color_dark = "#9a9a9a"         # default is #9a9a9a
     table_border_color_dark = "#515151" # default is #515151
     table_stripe_color_dark = "#202020" # default is #202020
+    code_color = "#bf616a"              # default is #bf616a
+    code_background_color = "#E5E5E5"   # default is #E5E5E5
+    code_color_dark = "##ff7f7f"        # default is #ff7f7f
+    code_background_color_dark = "#393D47" # default is #393D47
 
 [taxonomies]
     series = 'series'

--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -14,8 +14,8 @@
         --date-color: {{ with .Site.Params.date_color }}{{ . }}{{ else }}#515151{{ end }};
         --table-border-color: {{ with .Site.Params.table_border_color }}{{ . }}{{ else }}#E5E5E5{{ end }};
         --table-stripe-color: {{ with .Site.Params.table_stripe_color }}{{ . }}{{ else }}#F9F9F9{{ end }};
-        --code-color: #bf616a;
-        --code-background-color: #E5E5E5;
+        --code-color: {{ with .Site.Params.code_color }}{{ . }}{{ else }}#bf616a{{ end }};
+        --code-background-color: {{ with .Site.Params.code_background_color }}{{ . }}{{ else }}#E5E5E5{{ end }};
         --moon-sun-color: {{ with .Site.Params.moon_sun_color }}{{ . }}{{ else }}#FFF{{ end }};
         --moon-sun-background-color: {{ with .Site.Params.moon_sun_background_color }}{{ . }}{{ else }}#515151{{ end }};
     }
@@ -28,8 +28,8 @@
         --date-color: {{ with .Site.Params.date_color_dark }}{{ . }}{{ else }}#9a9a9a{{ end }};
         --table-border-color: {{ with .Site.Params.table_border_color_dark }}{{ . }}{{ else }}#515151{{ end }};
         --table-stripe-color: {{ with .Site.Params.table_stripe_color_dark }}{{ . }}{{ else }}#202020{{ end }};
-        --code-color: #ff7f7f;
-        --code-background-color: #393D47;
+        --code-color: {{ with .Site.Params.code_color_dark }}{{ . }}{{ else }}#ff7f7f{{ end }};
+        --code-background-color: {{ with .Site.Params.code_background_color_dark }}{{ . }}{{ else }}#393D47{{ end }};
     }
     body {
         background-color: var(--bkg-color);


### PR DESCRIPTION
The default code colors are awesome! But it would be great if the user could theme it more to their tastes. :smile: 

This turns the code colors into variables so that the user can set them in config.toml