### PR TITLE
Add note about single section pages to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Any items you want displayed in your sidebar menu *must* satisfy two requirement
 
 There are two types of menu items:
 
-1. **Single Page** -- The *About* menu item (to the left) is a good example of this.  It displays a direct link to an individual page.
+1. **Single Page** -- The *About* menu item (to the left) is a good example of this.  It displays a direct link to an individual page. For arbitrary single pages, the page content must be located at `content/<foo>/_index.md` and the front matter of `_index.md` must contain `layout: single`.
 2. **List** -- The *Posts* menu item is a good example of this.  It displays a directory and dynamically lists the contents (i.e. pages) contained by date.  List items have two optional configurations: a subheading (like the *Recent* subheading that appears on the menu to the left), and a maximum number of items to display.
 
 The sidebar menu items are configured with a dictionary value in your *config.toml* file.  I've included an example below.  Additionally, there is a placeholder for this in the *config.toml* file shown in the next section.
@@ -153,6 +153,9 @@ menu = [
         # ... /content/about/about.md
         {Name = "About", URL = "/about/", HasChildren = false},
         
+        # ... /content/foo/_index.md
+        # {Name = "Foo", URL = "/foo/", HasChildren = false},
+
         # LIST
         # This example has a subheading of "Recent"
         # and will display up to 5 items.


### PR DESCRIPTION
Section pages (other than projects.md and about.md which have custom layouts) must be named `_index.html` in order to declare a branch bundle and therefore a SiteSection. The default layout for these pages is `list.html` and needs to be forced to `single.html` in order to display as a single page.

I know that this is not technically an issue, but as a new user I found it confusing and wondered for a while why I couldn't seem to add single pages in the menu other than 'about' and 'projects'