### PR TITLE
Allow users to override CSS settings with their own `custom.css`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All of the static assets for the site (JS files, CSS, and fonts) are located wit
 - [How to Configure](#how-to-configure)
   - [The Sidebar Menu](#the-sidebar-menu)
   - [Example Config](#example-config)
+  - [Custom CSS](#custom-css)
 - [Author](#author)
 - [Ported by](#ported-by)
 - [License](#license)
@@ -253,6 +254,19 @@ pluralizelisttitles = false   # removes the automatically appended "s" on sideba
 [taxonomies]
     series = 'series'
     tags = 'tags'
+```
+
+### Custom CSS
+
+You can override any setting in Poison's static CSS files by adding your own
+`/static/css/custom.css` file. For example, if you want to override the title font and
+font size, you could add this:
+
+```css
+.sidebar-about h1 {
+  font-size: 1.4em;
+  font-family: "Monaco", monospace;
+}
 ```
 
 ## Author

--- a/layouts/partials/head/stylesheets.html
+++ b/layouts/partials/head/stylesheets.html
@@ -5,3 +5,6 @@
 <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/fonts.css">
 <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/katex.min.css">
 <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/tabs.css">
+
+<!-- Custom CSS so that users can override settings above. Load this last. -->
+<link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/custom.css">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,1 @@
+/* Empty css file that users can override in their own /static/css/custom.css file */


### PR DESCRIPTION
I found myself wanting to override some of Poison's CSS settings but still wanted to be able to pull from the repo to update without maintaining a branch on top of it.

This adds an empty `custom.css` file in `static/css` that users can easily override.  It's included from `stylesheets.html` *last*, so anything you put in your top-level `static/css/custom.css` will override the defaults from Poison.

For example, I did this to get a different title font:

```css
.sidebar-about h1 {
  font-size: 1.4em;
  font-family: "Monaco", monospace;
}
```