### PR TITLE
This fixes up the spacing issue between TOC and content + more semantic markup of content

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,8 @@
 {{ define "main" -}}
-<div class="post">
+<article class="post">
   {{ partial "post/info.html" . }}
   {{ .Content }}
   {{ partial "post/navigation.html" . }}
-  {{ partial "table_of_contents.html" . }}
-</div>
-
+</article>
+{{ partial "table_of_contents.html" . }}
 {{- end }}

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -1,4 +1,4 @@
-<div class="info">
+<section class="info">
     <h1 class="post-title">
         <a href="{{ .Permalink }}">{{ .Title }}</a>
     </h1>
@@ -27,4 +27,4 @@
         <img src="{{.Params.featuredImage}}"><br>
     </p>
     {{ end }}
-</div>
+</section>

--- a/layouts/partials/sidebar/sidebar.html
+++ b/layouts/partials/sidebar/sidebar.html
@@ -1,4 +1,4 @@
-<aside class="sidebar">
+<nav class="sidebar">
     <div class="container sidebar-sticky">
         {{ partial "light_dark.html" . }}
         {{ partial "sidebar/title.html" . }}
@@ -6,4 +6,4 @@
         {{ partial "sidebar/socials.html" . }}
         {{ partial "sidebar/copyright.html" . }}
   </div>
-</aside>
+</nav>

--- a/layouts/partials/table_of_contents.html
+++ b/layouts/partials/table_of_contents.html
@@ -1,4 +1,6 @@
 <div class="article-toc {{if .Site.Params.layoutReverse}}layout-reverse{{end}}" {{ if .Site.Params.SmartToc }}style="display:none;"{{ end }}>
-    <h4>{{ T "Contents" }}</h4>
-    {{ .TableOfContents }}
+    <div class="toc-wrapper">
+      <h4>{{ "Contents" }}</h4>
+      {{ .TableOfContents }}
+    </div>
 </div>

--- a/static/css/hyde.css
+++ b/static/css/hyde.css
@@ -160,13 +160,13 @@ a.sidebar-nav-item:focus {
  * with a 25%-wide `.sidebar`.
  */
 
-.content {
+.content > article {
   padding-top:    2rem;
   padding-bottom: 2rem;
 }
 
 @media (min-width: 48em) {
-  .content {
+  .content > article {
     max-width: 38rem;
     margin-left: 20rem;
     margin-right: 2rem;
@@ -174,7 +174,7 @@ a.sidebar-nav-item:focus {
 }
 
 @media (min-width: 64em) {
-  .content {
+  .content > article {
     max-width: 44rem;
     margin-left: 20rem;
     margin-right: 2rem;

--- a/static/css/poison.css
+++ b/static/css/poison.css
@@ -66,6 +66,9 @@ h1, h2, h3, h4, h5, strong {
     background-color: var(--moon-sun-background-color);
 }
 /* ************************** */
+.container.content {
+ display: flex;
+}
 .layout-reverse .content {
     margin-left: 20em;
 }
@@ -161,19 +164,20 @@ tbody tr:nth-child(odd) th {
 }
 .article-toc {
     display: none;
-    position: fixed;
-    left: 50%;
     top: 110px;
     font-size: 0.9em;
     width: 20em;
-    margin-left: 400px;
     padding-left: 20px;
     overflow-y: auto;
     line-height: 1.4em;
     max-height: 85%;
+    margin-top: 5em;
 }
 .article-toc nav {
-    margin-left: 5em;
+    margin-left: 1em;
+}
+.article-toc .toc-wrapper {
+    position: fixed;
 }
 .article-toc.layout-reverse {
     display: none;
@@ -191,9 +195,10 @@ tbody tr:nth-child(odd) th {
     margin-left: 0;
 }
 .article-toc h4 {
-    margin-left: 6em;
+    margin-left: 0em;
 }
 .article-toc ul {
+    padding: 0;
     margin-bottom: 0;
 }
 .article-toc li {

--- a/static/css/poole.css
+++ b/static/css/poole.css
@@ -240,13 +240,13 @@ img {
  * Center the page content.
  */
 
-/*.container {
-  max-width: 38rem;
+.container {
+/*  max-width: 38rem;*/
   padding-left:  1rem;
   padding-right: 1rem;
   margin-left:  auto;
   margin-right: auto;
-}*/
+}
 
 
 /*

--- a/static/css/poole.css
+++ b/static/css/poole.css
@@ -240,13 +240,13 @@ img {
  * Center the page content.
  */
 
-.container {
+/*.container {
   max-width: 38rem;
   padding-left:  1rem;
   padding-right: 1rem;
   margin-left:  auto;
   margin-right: auto;
-}
+}*/
 
 
 /*


### PR DESCRIPTION
This fixes the issue of a large left margin on the Article TOC when on wide screens, it scales gracefully down to smaller screens as well and prepares the markup for future user configurable content width (removes using %).

In theory this breaks layoutReverse - but in actually it's currently broken anyway due to a missing space after the class name on <body>., it's also very broken on widescreen as well and doesn't swap the TOC anyway.  I plan to do another PR to fix all of those issues at some point this week.