### PR TITLE
Switch to flexbox for layout rather than using positioning and margins

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 {{ partial "head/head.html" . }}
-    <body class="{{if .Site.Params.layoutReverse}}layout-reverse{{end}}{{if .Site.Params.dark_mode}}dark-theme{{end}}">
+    <body class="{{if .Site.Params.layoutReverse}}layout-reverse {{end}}{{if .Site.Params.dark_mode}}dark-theme{{end}}">
         <div class="wrapper">
             {{ partial "sidebar/sidebar.html" . }}
             <main class="content container">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,8 +1,11 @@
 {{ partial "head/head.html" . }}
     <body class="{{if .Site.Params.layoutReverse}}layout-reverse{{end}}{{if .Site.Params.dark_mode}}dark-theme{{end}}">
-        {{ partial "sidebar/sidebar.html" . }}
-        <main class="content container">
-            {{ block "main" . -}}{{- end }}
-        </main>
+        <div class="wrapper">
+            {{ partial "sidebar/sidebar.html" . }}
+            <main class="content container">
+                {{ block "main" . -}}{{- end }}
+            </main>
+            {{ block "sidebar" . }}{{ end }}
+        </div>
     </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,8 @@
   {{ partial "post/info.html" . }}
   {{ .Content }}
   {{ partial "post/navigation.html" . }}
-  {{ partial "table_of_contents.html" . }}
 </div>
-
 {{- end }}
+{{ define "sidebar" }}
+  {{ partial "table_of_contents.html" . }}
+{{ end }}

--- a/layouts/partials/table_of_contents.html
+++ b/layouts/partials/table_of_contents.html
@@ -1,4 +1,6 @@
 <div class="article-toc {{if .Site.Params.layoutReverse}}layout-reverse{{end}}" {{ if .Site.Params.SmartToc }}style="display:none;"{{ end }}>
-    <h4>{{ T "Contents" }}</h4>
-    {{ .TableOfContents }}
+    <div class="toc-wrapper">
+      <h4>{{ "Contents" }}</h4>
+      {{ .TableOfContents }}
+    </div>
 </div>

--- a/static/css/hyde.css
+++ b/static/css/hyde.css
@@ -171,7 +171,7 @@ a.sidebar-nav-item:focus {
   .content {
     max-width: 38rem;
     margin-left: 2rem;
-    margin-right: 2rem;
+    margin-right: 1.75rem;
   }
 }
 
@@ -179,7 +179,7 @@ a.sidebar-nav-item:focus {
   .content {
     max-width: 44rem;
     margin-left: 2rem;
-    margin-right: 2rem;
+    margin-right: 1.75rem;
   }
 }
 
@@ -205,6 +205,25 @@ a.sidebar-nav-item:focus {
 .brand {
   font-size: 4.0em;
   margin-bottom: 0;
+}
+
+/*
+ * Reverse layout
+ */
+@media (min-width: 48em) {
+  .content {
+    max-width: 38rem;
+    margin-left: 1.75rem;
+    margin-right: 2rem;
+  }
+}
+
+@media (min-width: 64em) {
+  .content {
+    max-width: 44rem;
+    margin-left: 1.75rem;
+    margin-right: 2rem;
+  }
 }
 
 /*

--- a/static/css/hyde.css
+++ b/static/css/hyde.css
@@ -208,32 +208,6 @@ a.sidebar-nav-item:focus {
 }
 
 /*
- * Reverse layout
- *
- * Flip the orientation of the page by placing the `.sidebar` on the right.
- */
-
-@media (min-width: 48em) {
-  .layout-reverse .sidebar {
-    left: auto;
-    right: 0;
-  }
-  .layout-reverse .content {
-    margin-left: 2rem;
-    margin-right: 20rem;
-  }
-}
-
-@media (min-width: 64em) {
-  .layout-reverse .content {
-    margin-left: 4rem;
-    margin-right: 22rem;
-  }
-}
-
-
-
-/*
  * Themes
  *
  * As of v1.1, Hyde includes optional themes to color the sidebar and links

--- a/static/css/hyde.css
+++ b/static/css/hyde.css
@@ -62,10 +62,10 @@ pre {
   text-align: center;
   padding: 2rem 1rem;
   color: rgba(255,255,255,.5);
+  flex-shrink: 0;
 }
 @media (min-width: 48em) {
   .sidebar {
-    position: fixed;
     top: 0;
     left: 0;
     bottom: 0;
@@ -144,12 +144,14 @@ a.sidebar-nav-item:focus {
  * contents to the bottom of the sidebar in tablets and up.
  */
 
+.sidebar-sticky {
+    position: fixed;
+}
+
 @media (min-width: 48em) {
   .sidebar-sticky {
-    position: absolute;
-    right:  1rem;
     top: 1rem;
-    left:   1rem;
+    width: 16rem;
   }
 }
 
@@ -168,7 +170,7 @@ a.sidebar-nav-item:focus {
 @media (min-width: 48em) {
   .content {
     max-width: 38rem;
-    margin-left: 20rem;
+    margin-left: 2rem;
     margin-right: 2rem;
   }
 }
@@ -176,7 +178,7 @@ a.sidebar-nav-item:focus {
 @media (min-width: 64em) {
   .content {
     max-width: 44rem;
-    margin-left: 20rem;
+    margin-left: 2rem;
     margin-right: 2rem;
   }
 }

--- a/static/css/poison.css
+++ b/static/css/poison.css
@@ -17,6 +17,12 @@
 }
 
 @media (max-width: 48em) {
+    body > .wrapper {
+       flex-direction: column;
+    }
+    .sidebar-sticky {
+       position: static;
+    }
     .heading {
         font-weight: 400;
     }
@@ -66,6 +72,27 @@ h1, h2, h3, h4, h5, strong {
     background-color: var(--moon-sun-background-color);
 }
 /* ************************** */
+body {
+    overflow: hidden;
+    height: 100vh;
+}
+body > .wrapper {
+    display: flex;
+    height: 100%;
+}
+.container.content {
+    overflow-y: auto;
+}
+.container.content::-webkit-scrollbar {
+   width: 3px;
+}
+.container.content::-webkit-scrollbar-thumb {
+   border-radius: 1.5px;
+}
+.container.content::-webkit-scrollbar-track {
+   margin-top: 5.5em;
+}
+
 .layout-reverse .content {
     margin-left: 20em;
 }
@@ -161,19 +188,19 @@ tbody tr:nth-child(odd) th {
 }
 .article-toc {
     display: none;
-    position: fixed;
-    left: 50%;
-    top: 110px;
     font-size: 0.9em;
     width: 20em;
-    margin-left: 400px;
+    margin-top: 5em;
     padding-left: 20px;
     overflow-y: auto;
     line-height: 1.4em;
     max-height: 85%;
 }
+.article-toc .toc-wrapper{
+    position: fixed;
+}
 .article-toc nav {
-    margin-left: 5em;
+    margin-left: 1em;
 }
 .article-toc.layout-reverse {
     display: none;
@@ -191,10 +218,11 @@ tbody tr:nth-child(odd) th {
     margin-left: 0;
 }
 .article-toc h4 {
-    margin-left: 6em;
+    margin-left: 0;
 }
 .article-toc ul {
     margin-bottom: 0;
+    padding: 0;
 }
 .article-toc li {
     list-style: none;

--- a/static/css/poison.css
+++ b/static/css/poison.css
@@ -91,6 +91,11 @@ body > .wrapper {
 }
 .container.content {
     overflow-y: auto;
+    padding-right: 2rem;
+}
+.layout-reverse .container.content {
+    padding-right: 0;
+    padding-left: 2rem;
 }
 .container.content::-webkit-scrollbar {
    width: 3px;
@@ -99,7 +104,7 @@ body > .wrapper {
    border-radius: 1.5px;
 }
 .container.content::-webkit-scrollbar-track {
-   margin-top: 5.5em;
+   margin: 5.5em 0;
 }
 
 .sidebar {
@@ -197,7 +202,6 @@ tbody tr:nth-child(odd) th {
     font-size: 0.9em;
     width: 20em;
     margin-top: 5em;
-    padding-left: 20px;
     overflow-y: auto;
     line-height: 1.4em;
     max-height: 85%;

--- a/static/css/poison.css
+++ b/static/css/poison.css
@@ -1,3 +1,12 @@
+body.layout-reverse .container.content {
+   direction: rtl;
+}
+
+body.layout-reverse .wrapper {
+   justify-content: flex-end;
+   flex-direction: row-reverse;
+}
+
 @media (min-width: 48em) {
     .bullet {
         margin-left: 1em;
@@ -17,7 +26,7 @@
 }
 
 @media (max-width: 48em) {
-    body > .wrapper {
+    body > .wrapper, body.layout-reverse .wrapper {
        flex-direction: column;
     }
     .sidebar-sticky {
@@ -93,9 +102,6 @@ body > .wrapper {
    margin-top: 5.5em;
 }
 
-.layout-reverse .content {
-    margin-left: 20em;
-}
 .sidebar {
     background-color: var(--sidebar-bg-color);
 }
@@ -202,21 +208,6 @@ tbody tr:nth-child(odd) th {
 .article-toc nav {
     margin-left: 1em;
 }
-.article-toc.layout-reverse {
-    display: none;
-    position: fixed;
-    left: 0%;
-    top: 110px;
-    font-size: 0.9em;
-    width: 20em;
-    margin-left: 0;
-    overflow-y: auto;
-    line-height: 1.4em;
-    max-height: 85%;
-}
-.article-toc.layout-reverse nav {
-    margin-left: 0;
-}
 .article-toc h4 {
     margin-left: 0;
 }
@@ -241,9 +232,6 @@ tbody tr:nth-child(odd) th {
 }
 @media screen and (min-width: 100em) {
     .article-toc {
-        display: block;
-    }
-    .article-toc.layout-reverse {
         display: block;
     }
 }

--- a/static/css/poole.css
+++ b/static/css/poole.css
@@ -244,7 +244,7 @@ img {
   max-width: 38rem;
   padding-left:  1rem;
   padding-right: 1rem;
-  margin-left:  auto;
+/*  margin-left:  auto;*/
   margin-right: auto;
 }
 


### PR DESCRIPTION
These two commits switch the normal layout initially to flexbox and then the reverse layout.  It removes quite a bit of CSS, especially for the reverse layout and improves the layout of the TOC, menu and content.

Addresses: https://github.com/lukeorth/poison/issues/52

Allows future easier addressing of: https://github.com/lukeorth/poison/issues/51

**Normal Layout**
![image](https://user-images.githubusercontent.com/5338970/224504521-81bcf62f-a64b-475d-9d85-19a80ec04c29.png)

**Reverse Layout**
![image](https://user-images.githubusercontent.com/5338970/224504492-251ffb3b-fef0-4acf-b165-fb1c175ac580.png)

**Narrow Width**
![image](https://user-images.githubusercontent.com/5338970/224504544-9c1e1e71-37a5-4914-b643-507bfc8b7602.png)

As always, happy to take feedback, especially if anyone spots any bugs.

