### PR TITLE
Fix mermaid and plantuml shortcode rendering.

### DIFF
--- a/layouts/partials/head/scripts.html
+++ b/layouts/partials/head/scripts.html
@@ -6,19 +6,6 @@
 <script defer language="javascript" type="text/javascript" src="{{ "js/katex.min.js" | absURL }}"></script>
 <script defer language="javascript" type="text/javascript" src="{{ "js/auto-render.min.js" | absURL }}"></script>
 
-<!-- Locally hosted code for PlantUML diagrams -->
-{{ if .Page.Store.Get "hasPlantUML" }}
-<script language="javascript" type="text/javascript" src="{{ "js/plantuml-encoder.min.js" | absURL }}"></script>
-<!-- Personal/custom scripts for PlantUML diagrams -->
-<script language="javascript" type="text/javascript" src="{{ "js/plantuml-encoder.js" | absURL }}"></script>
-{{ end }}
-
 <!-- Personal/custom scripts for KaTeX and table of contents -->
 <script defer language="javascript" type="text/javascript" src="{{ "js/katex.js" | absURL }}"></script>
 <script defer language="javascript" type="text/javascript" src="{{ "js/toc.js" | absURL }}"></script>
-
-<!-- To automatically render mermaid diagrams -->
-{{ if .Page.Store.Get "hasMermaid" }}
-<script defer language="javascript" type="text/javascript" src="{{ "js/mermaid.min.js" | absURL }}"></script>
-<script>mermaid.initialize({ startOnLoad: true });</script>
-{{ end }}

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,4 +1,10 @@
+<!-- To automatically render mermaid diagrams -->
+{{ if ne (.Page.Scratch.Get "hasMermaid") true }}
+<script defer language="javascript" type="text/javascript" src="{{ "js/mermaid.min.js" | absURL }}"></script>
+<script>mermaid.initialize({ startOnLoad: true });</script>
+{{ .Page.Scratch.Set "hasMermaid" true }}
+{{ end }}
+
 <div class="mermaid">
   {{- .Inner | safeHTML }}
 </div>
-{{ .Page.Store.Set "hasMermaid" true }}

--- a/layouts/shortcodes/plantuml.html
+++ b/layouts/shortcodes/plantuml.html
@@ -1,3 +1,10 @@
+<!-- Locally hosted code for PlantUML diagrams -->
+{{ if ne (.Page.Scratch.Get "hasPlantUML") true }}
+<script language="javascript" type="text/javascript" src="{{ "js/plantuml-encoder.min.js" | absURL }}"></script>
+<!-- Personal/custom scripts for PlantUML diagrams -->
+<script language="javascript" type="text/javascript" src="{{ "js/plantuml-encoder.js" | absURL }}"></script>
+{{ .Page.Scratch.Set "hasPlantUML" true }}
+{{ end }}
+
 <span id="plantuml-{{ .Get "id" }}" style="display:none">{{ .Inner | safeHTML | htmlUnescape }}</span>
 <img class="plantuml" id="plantuml-{{ .Get "id" }}">
-{{ .Page.Store.Set "hasPlantUML" true }}


### PR DESCRIPTION
I noticed that the mermaid/plantuml diagrams do not render.
The reason is that the head/scripts.html is rendered first before the shortcode templates.
That means the .Page.store.Get is still false so the javascript doesn't get included.