### PR TITLE
post/info: do not display date if not provided

### DIFF
--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -2,9 +2,11 @@
     <h1 class="post-title">
         <a href="{{ .Permalink }}">{{ .Title }}</a>
     </h1>
-    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}" class="post-date">
-        {{ .Date.Format "January 2, 2006" }}
-    </time>
+    {{ if .Date }}
+        <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}" class="post-date">
+            {{ .Date.Format "January 2, 2006" }}
+        </time>
+    {{ end }}
     {{ if .Params.tags }}
     <ul class="tags">
         {{ range .Params.tags }}


### PR DESCRIPTION
Allows the use of the default post layout for categories that aren't necessarily dated.