### PR TITLE
Change code link color to --link-color

### DIFF
--- a/static/css/poison.css
+++ b/static/css/poison.css
@@ -73,6 +73,9 @@ h1, h2, h3, h4, h5, strong {
     color: var(--code-color);
     background-color: var(--code-background-color) !important;
 }
+.content a code{
+    color: var(--link-color);
+}
 .content pre {
   color: var(--code-color);
   background-color: var(--code-background-color);


### PR DESCRIPTION
It seemed sensible that code that's also a link should also take on the link color :)

**Before**
![before](https://github.com/lukeorth/poison/assets/124381111/b8aa7acd-9ca8-4cb9-a708-0b4ec4cf97c9)

**After**
![after](https://github.com/lukeorth/poison/assets/124381111/ba1de9a8-4520-4a43-b38e-165e8c173db8)
