### PR TITLE
js/toc: don't break on pages with no TOC sidebar

### DIFF
--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -10,7 +10,10 @@ let activeElement = null;
 window.addEventListener('DOMContentLoaded', () => {
     const observer = new IntersectionObserver(entries => {
         if (entries) {
-            document.getElementById("contents").innerHTML = "Contents";
+            const contents = document.getElementById("contents");
+            if (contents) {
+                contents.innerHTML = "Contents";
+            }
         }
         entries.forEach(entry => {
             if (activeElement) {


### PR DESCRIPTION
Fixes a JS error when toc.js is included on pages that have headers but don't have a TOC sidebar (in my case, this happens on the homepage, for example).

I went for the most obvious/trivial fix but I don't fully understand this code, it could be there's a better solution that I've missed.