### PR TITLE
FIX: Paginator behavior with other sections

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" -}}
 <div class="posts">
-    {{ range where .Paginator.Pages "Section" "eq" "posts" }}
+    {{ range (.Paginate (where .Site.RegularPages "Type" "posts")).Pages }}
     <article class="post">
         {{ partial "post/info.html" . }}
         {{ .Summary }}


### PR DESCRIPTION
I noticed that if i had posts in other sections which were being picked up by the Paginator, it would show weird behavior on the index page of the site.

For example only showing a single post if I had made 9 other posts in another section that shouldn't show up on the main page.

This commit changes it such that it filters to the "posts" section first, then paginates.