### PR TITLE
Allows users to supply a flag in the frontmatter to disable the table…

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,5 +9,7 @@
 </div>
 {{- end }}
 {{ define "sidebar" }}
-  {{ partial "table_of_contents.html" . }}
+  {{ if not (.Params.hideToc) }}
+    {{ partial "table_of_contents.html" . }}
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
This change allows a user to supply a tag in the frontmatter for a post that will disable the table of contents.  For example:

`hideToc: true`

will disable the table of contents.

`hideToc: false`

will display the table of contents if you want to be explicit.  I used the verb hide to facilitate cases where the flag is not explicitly set - which will be the case for all existing posts.  The absence of the flag will display the table of contents.

If accepted and merged, this would close #110 