### PR TITLE
Adding support for Plausible integration

### DIFF
--- a/layouts/partials/head/scripts.html
+++ b/layouts/partials/head/scripts.html
@@ -19,3 +19,8 @@
 {{ $js_bundle := $js | resources.Concat "js/bundle.js" | minify | fingerprint }}
 
 <script defer language="javascript" type="text/javascript" src="{{ $js_bundle.RelPermalink }}"></script>
+
+
+{{ if .Site.Params.plausible }}
+<script defer data-domain="{{ .Site.Params.plausible_domain }}" src="{{ .Site.Params.plausible_script }}"></script>
+{{ end }}


### PR DESCRIPTION
The [self-hosted version](https://github.com/plausible/analytics) of [Plausible](https://plausible.io) is a great alternative to Google Analytics.  Once you have Plausible set up, tracking your site traffic is as simple as adding something like this to the ```<head>``` of each page:

```<script defer data-domain="myblog.com" src="https://plausible.myblog.com/js/script.js"></script>```

where "myblog.com" is the domain for your blog, and "plausible.myblog.com" is the FQDN or hostname for your plausible installation.  My proposal is to update the scripts.html file in layouts/partials/head/ so that you can optionally add support for Plausible.

Your sitewide config.toml would have this configuration to add support for plausible:

```
[params]
    plausible = true
    plausible_domain = "myblog.com"
    plausible_script = "https://plausible.myblog.com/js/script.js"
```

I am certainly not fully aware of Hugo best practices, so please feel free to reject, adjust, or provide candid feedback.  Thank you!