### PR TITLE
Changed menu.html to add headings based on taxonomy terms

### DIFF
--- a/layouts/partials/sidebar/menu.html
+++ b/layouts/partials/sidebar/menu.html
@@ -36,6 +36,23 @@
                         <a href="{{$menu_item.URL }}">{{ $menu_item.Name }}</a>
                     </li>
                 {{ end }}
+                {{ range $term, $page := $taxonomy }}
+                        {{ if eq (lower $term) (lower $menu_item.Name) }}
+                            <li class="heading">
+                                <a href="{{$menu_item.URL }}">{{ $menu_item.Name }}</a>
+                            </li>
+                            {{ if $menu_item.HasChildren }}
+                            <li class="sub-heading">
+                                {{ $menu_item.Pre }}
+                            </li>
+                            {{ range (first $menu_item.Limit .Pages) }}
+                                <li class="bullet">
+                                    <a href="{{ .Permalink }}">{{ .Title }}</a>
+                                </li>
+                            {{ end }}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
             {{ end }}
         {{ end }}
 


### PR DESCRIPTION
I intend to create headings on the sidebar menu based on taxonomy terms. For instance, if a post is tagged with 'Development', my goal is to display the most recent posts under this tag in the sidebar menu. This functionality should also extend to posts that are part of a series.

This ensure the following works in my hugo.toml:
`[params]
	menu = [
		{Name = "Development", URL = "/tags/Development/", HasChildren = true, Limit = 2},
	]
`
