### PR TITLE
this fixes an issue with some images displaying with weird aspect ratios

### DIFF
--- a/assets/css/poole.css
+++ b/assets/css/poole.css
@@ -207,6 +207,7 @@ img {
   margin: 0 0 1rem;
   border-radius: 5px;
   max-width: 100%;
+  height: auto;
 }
 
 


### PR DESCRIPTION
this fixes an issue with some images displaying with weird aspect ratios, in particular on mobile.

without:
<img width="284" alt="image" src="https://github.com/lukeorth/poison/assets/19483938/f977f492-fc03-428a-96c3-c2d81e534b30">


with:
<img width="391" alt="image" src="https://github.com/lukeorth/poison/assets/19483938/68747246-c0ba-4928-bb40-95e952dc4954">
