### PR TITLE
Implemented a possibility to enable email newsletters subscription by using Listmonk

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All the static assets for the site (JS files, CSS, and fonts) are located within
     - [Table of Contents](#table-of-contents)
     - [Comments](#comments)
     - [Analytics](#analytics)
+    - [Email Newsletters Subscription](#email-newsletters-subscription)
     - [Series](#series)
     - [KaTeX](#katex)
     - [Tabs](#tabs)
@@ -122,6 +123,27 @@ For reference, the configuration above would add the following code to each page
 
 ```<script defer data-domain="myblog.com" src="https://plausible.myblog.com/js/script.js"></script>```
 
+### Email Newsletters Subscription
+
+Allow users to subscribe to your blog newsletters via email. 
+Poison currently supports [Listmonk](https://listmonk.app/) which is available via [self-hosting](https://github.com/knadh/listmonk).
+Listmonk is a standalone, self-hosted, newsletter and mailing list manager.
+The downside is that you must host it yourself. 
+Checkout the Listmonk [documentation](https://listmonk.app/docs/) to get started.
+
+Once you've established your Listmonk instance, you can activate it by adding these lines to your ```config.toml``` file.
+
+```toml
+[params]
+    listmonk = true
+    listmonk_host = "https://listmonk.your_domain.tld"
+    listmonk_subscription_list_uiid = "YOUR_NEWSLETTERS_LIST_UIID"
+    listmonk_subscription_form_text = "Subscribe to my newsletters"       # default: Subscribe to my newsletters
+    listmonk_subscription_success_message = "Thanks for subscribing"     # default: Thanks for subscribing
+    listmonk_subscription_error_message = "Something went wrong"           # default: Sorry, something went wrong. Please, try again
+```
+This will insert a form to the bottom of each post content. 
+The user will be subscribed to the newsletter list you specified in the `listmonk_subscription_list_uiid` parameter.
 
 ### Series
 Sensibly link and display content into "series" (i.e. *Tutorial One*, *Tutorial Two*, etc.).

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Once you've established your Listmonk instance, you can activate it by adding th
     listmonk_host = "https://listmonk.your_domain.tld"
     listmonk_subscription_list_uiid = "YOUR_NEWSLETTERS_LIST_UIID"
     listmonk_subscription_form_text = "Subscribe to my newsletters"       # default: Subscribe to my newsletters
-    listmonk_subscription_success_message = "Thanks for subscribing"     # default: Thanks for subscribing
-    listmonk_subscription_error_message = "Something went wrong"           # default: Sorry, something went wrong. Please, try again
+    listmonk_subscription_success_message = "Thanks for subscribing"      # default: Thanks for subscribing
+    listmonk_subscription_error_message = "Something went wrong"          # default: Sorry, something went wrong. Please, try again
 ```
 This will insert a form to the bottom of each post content. 
 The user will be subscribed to the newsletter list you specified in the `listmonk_subscription_list_uiid` parameter.

--- a/assets/css/poison.css
+++ b/assets/css/poison.css
@@ -165,6 +165,55 @@ body > .wrapper {
 .info ul li {
     margin-left: 0.5em;
 }
+.newsletters .help-block-for-success {
+    display: none;
+    margin: 0.25rem 1rem 0.25rem 0;
+    text-align: center;
+    color: green;
+}
+.newsletters .help-block-for-error {
+    display: none;
+    margin: 0.25rem 1rem 0.25rem 0;
+    text-align: center;
+    color: #de0928;
+}
+.newsletters .help-block-show {
+    display: block;
+}
+.newsletters form {
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    flex-flow: row wrap;
+}
+.newsletters .email-subscription-form-hide {
+    display: none;
+}
+.newsletters label {
+    margin: 0.25rem 1rem 0.25rem 0;
+    text-align: center;
+}
+.newsletters input {
+    margin: 0.25rem 1rem 0.25rem 0;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--text-color);
+    border-radius: 0.25rem;
+}
+.newsletters input:focus-visible {
+    outline: none;
+}
+.newsletters button {
+    background-color: transparent;
+    color: var(--text-color);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--text-color);
+    font-family: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    margin: 0.25rem 0;
+}
 .tags {
     padding-left: 0em;
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,6 +2,9 @@
 <div class="post">
   {{ partial "post/info.html" . }}
   {{ .Content }}
+  {{ if (.Site.Params.listmonk) }}
+    {{ partial "post/listmonk_email_newsletters.html" . }}
+  {{ end }}
   {{ partial "post/navigation.html" . }}
   {{ if or (.Site.Params.remark42) (.Site.DisqusShortname) }}
     {{ partial "post/comments.html" . }}

--- a/layouts/about/about.html
+++ b/layouts/about/about.html
@@ -7,5 +7,8 @@
         <h1 class="post-title">{{ .Title }}</h1>
         {{ .Content }}
     {{ end }}
+    {{ if (.Site.Params.listmonk) }}
+        {{ partial "post/listmonk_email_newsletters.html" . }}
+    {{ end }}
 </div>
 {{ end }}

--- a/layouts/partials/post/listmonk_email_newsletters.html
+++ b/layouts/partials/post/listmonk_email_newsletters.html
@@ -1,0 +1,50 @@
+<hr>
+<div class="newsletters">
+    <div class="help-block-for-success"></div>
+    <div class="help-block-for-error"></div>
+    <form id="email-subscription-form">
+        <label for="email-subscription-input">{{ .Site.Params.listmonk_subscription_form_text | default "Subscribe to my newsletters" }}</label>
+        <input type="email" id="email-subscription-input" name="email-subscription-input" placeholder="Email address" />
+        <button type="submit">Subscribe</button>
+    </form>
+
+    <script>
+      const listmonkHost = {{ .Site.Params.listmonk_host }};
+      const listmonkSubscriptionSuccessMessage = {{ .Site.Params.listmonk_subscription_success_message | default "Thanks for subscribing" }};
+      const listmonkSubscriptionErrorMessage = {{ .Site.Params.listmonk_subcription_error_message | default "Sorry, something went wrong. Please, try again" }};
+
+      const form = document.getElementById("email-subscription-form");
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const email = form.querySelector("#email-subscription-input").value;
+        const data = {
+          email: email,
+          list_uuids: [
+            {{ .Site.Params.listmonk_subscription_list_uiid }}
+          ]
+      };
+        fetch(`${listmonkHost}/api/public/subscription`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(data),
+        }).then((response) => {
+          if (response.status === 200) {
+            const successBlock = document.getElementsByClassName('help-block-for-success')[0];
+            successBlock.classList.add('help-block-show');
+            successBlock.textContent = listmonkSubscriptionSuccessMessage;
+            document.getElementById('email-subscription-form').classList.add('email-subscription-form-hide');
+          } else {
+            const errorBlock = document.getElementsByClassName('help-block-for-error')[0];
+            errorBlock.classList.add('help-block-show');
+            errorBlock.textContent = listmonkSubscriptionErrorMessage;
+          }
+        }).catch(() => {
+          const errorBlock = document.getElementsByClassName('help-block-for-error')[0];
+          errorBlock.classList.add('help-block-show');
+          errorBlock.textContent = listmonkSubscriptionErrorMessage;
+        });
+      })
+    </script>
+</div>


### PR DESCRIPTION
Here are the configs required to add to the `config.toml`/`hugo.toml` file:
```
    # Listmonk
    listmonk = true 
    listmonk_host = "https://listmonk.your_domain.tld"
    listmonk_subscription_list_uiid = "YOUR_NEWSLETTERS_LIST_UIID"
    listmonk_subscription_form_text = "Subscribe to my newsletters"                # default: Subscribe to my newsletters
    listmonk_subscription_success__message = "Thanks for subscribing"         # default: Thanks for subscribing
    listmonk_subcription_error_message = "Something went wrong"                  # default: Sorry, something went wrong. Please, try again
```

Here is how it looks for the dark theme:
![CleanShot 2023-10-15 at 22 15 53](https://github.com/lukeorth/poison/assets/24653053/4b139bf0-8e25-4e46-8779-b7c564206877)

and for the light one:
![CleanShot 2023-10-15 at 22 17 50](https://github.com/lukeorth/poison/assets/24653053/8fa1ed90-ce78-4f66-8d5d-059a933dc16d)

It is also added to the `About` page:
- dark:
![CleanShot 2023-10-15 at 22 23 50](https://github.com/lukeorth/poison/assets/24653053/90d15540-40c6-41e0-aaa3-418b85700157)
- light:
![CleanShot 2023-10-15 at 22 24 20](https://github.com/lukeorth/poison/assets/24653053/1ad5968d-25ea-475d-96e6-a449bc7dbc7e)

The way it looks when the error happens:
- dark:
![CleanShot 2023-10-15 at 22 25 18](https://github.com/lukeorth/poison/assets/24653053/5c7baca2-3972-4a3d-bb8b-af470762259c)
- light:
![CleanShot 2023-10-15 at 22 26 09](https://github.com/lukeorth/poison/assets/24653053/773f5144-7769-4e99-8c39-5e483f325a37)

On successful subscription:
- dark:
![CleanShot 2023-10-15 at 22 27 20](https://github.com/lukeorth/poison/assets/24653053/38ff0706-3ea8-49cc-a76c-7076b1b10fe8)
- light:
![CleanShot 2023-10-15 at 22 27 49](https://github.com/lukeorth/poison/assets/24653053/a4be5889-dbef-4e70-8366-5a75f1196bd6)
