### PR TITLE
Feat: Add ability to use remote brand image

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ When visiting the base url for the site, i.e. `your.domain.com/`, a paginated fe
 ### Example config
 I recommend starting by copying/pasting the following code into your config.toml file.  Once you see how it looks, play with the settings as needed.
 
-**NOTE**: To display an image in your sidebar, you'll need to uncomment the `brand_image` path below and have it point to an image file in your project.  The path is relative to the `static` directory.  If you don't have an image, just leave this line commented out.
+**NOTE**: To display an image in your sidebar, you'll need to uncomment the `remote_brand_image` and set a image URL or the `brand_image` path below and have it point to an image file in your project.  The path is relative to the `static` directory.  If you don't have an image, just leave both lines commented out.
 
 ```toml
 baseURL = "/"
@@ -320,6 +320,7 @@ pluralizelisttitles = false   # removes the automatically appended "s" on sideba
 
 [params]
     brand = "Poison"                      # name of your site - appears in the sidebar
+    # remote_brand_image = 'https://github.com/USERNAME.png' # path to a remote file
     # brand_image = "/images/test.jpg"    # path to the image shown in the sidebar
     description = "Update this description..." # Used as default meta description if not specified in front matter
     dark_mode = true                      # optional - defaults to false

--- a/layouts/partials/sidebar/title.html
+++ b/layouts/partials/sidebar/title.html
@@ -1,15 +1,22 @@
 <div class="sidebar-about">
     <h1 class="brand">
-        {{ if .Site.Params.brand_image }}
+        {{ if .Site.Params.remote_brand_image }}
             <a href="{{ .Site.BaseURL }}">
-                <img src="{{ .Site.Params.brand_image }}" alt="brand image">
+                <img src="{{ .Site.Params.remote_brand_image }}" alt="brand image">
             </a>
+        {{ else }}
+            {{ if .Site.Params.brand_image }}
+                <a href="{{ .Site.BaseURL }}">
+                    <img src="{{ .Site.Params.brand_image }}" alt="brand image">
+                </a>
+            {{ end }}
+            {{ if .Site.Params.brand }}
+                <a href="{{ .Site.BaseURL }}">
+                    <h1>{{ .Site.Params.brand }}</h1>
+                </a>
+            {{ end }}
         {{ end }}
-        {{ if .Site.Params.brand }}
-            <a href="{{ .Site.BaseURL }}">
-                <h1>{{ .Site.Params.brand }}</h1>
-            </a>
-        {{ end }}
+
     </h1>
     <p class="lead">
     {{ with .Site.Params.description }}{{. | safeHTML}}{{end}}

--- a/layouts/partials/sidebar/title.html
+++ b/layouts/partials/sidebar/title.html
@@ -4,19 +4,16 @@
             <a href="{{ .Site.BaseURL }}">
                 <img src="{{ .Site.Params.remote_brand_image }}" alt="brand image">
             </a>
-        {{ else }}
-            {{ if .Site.Params.brand_image }}
-                <a href="{{ .Site.BaseURL }}">
-                    <img src="{{ .Site.Params.brand_image }}" alt="brand image">
-                </a>
-            {{ end }}
-            {{ if .Site.Params.brand }}
-                <a href="{{ .Site.BaseURL }}">
-                    <h1>{{ .Site.Params.brand }}</h1>
-                </a>
-            {{ end }}
+        {{ else if .Site.Params.brand_image }}
+            <a href="{{ .Site.BaseURL }}">
+                <img src="{{ .Site.Params.brand_image }}" alt="brand image">
+            </a>
         {{ end }}
-
+        {{ if .Site.Params.brand }}
+            <a href="{{ .Site.BaseURL }}">
+                <h1>{{ .Site.Params.brand }}</h1>
+            </a>
+        {{ end }}
     </h1>
     <p class="lead">
     {{ with .Site.Params.description }}{{. | safeHTML}}{{end}}


### PR DESCRIPTION
## Problem
I'm frequently updating my brand image in my blog, and every time, I need to include a new photo in the folder and update things manually.

## Proposal
Include a new param in `hugo.toml` to point to a remote image and use it in the sidebar, so people won't constantly need to update it manually.

## Use case
In my case, I'd like my blog always to have the same avatar as I have in GitHub, so I can add a link to my GitHub account picture and use it instead.

- Easy to update
- Easy to configure
- Less handwork

## Demo
- Go to my blog [https://lucasgrocha.com/](https://lucasgrocha.com/)
- Inspect my brand image
- Check the `src` attribute of the `<img>` tag

## Notes
I updated my GitHub avatar and the blog has synced successfully with the GitHub by showing the new avatar there.
