### PR TITLE
Removed the `| humanize | title` from the webpage title to keep the text in the desired registry rather than forcing the uppercase one

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -13,13 +13,13 @@
 {{ end }}
 
 {{ if .IsSection }}
-  {{ .Scratch.Set "title" ($.Site.Params.brand | humanize | title) }}
+  {{ .Scratch.Set "title" ($.Site.Params.brand) }}
   {{ .Scratch.Add "title" " - " }}
   {{ .Scratch.Add "title" .LinkTitle }}
 {{ end }}
 
 {{ if .IsPage }}
-  {{ .Scratch.Set "title" ($.Site.Params.brand | humanize | title) }}
+  {{ .Scratch.Set "title" ($.Site.Params.brand) }}
   {{ .Scratch.Add "title" " - " }}
   {{ .Scratch.Add "title" .LinkTitle }}
 {{ end }}


### PR DESCRIPTION
A fix for #152 