### PR TITLE
Feat: Add reading time

### DIFF
--- a/assets/css/poison.css
+++ b/assets/css/poison.css
@@ -166,6 +166,16 @@ body > .wrapper {
 .info ul li {
     margin-left: 0.5em;
 }
+.headline {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    align-content: center;
+}
+.reading-time {
+    color: gray;
+    font-style: italic;
+}
 .newsletters .help-block-for-success {
     display: none;
     margin: 0.25rem 1rem 0.25rem 0;

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -13,9 +13,9 @@
       <span> - </span>
       <span class="reading-time">
         {{ if gt .ReadingTime 1 }}
-          {{ .Scratch.Set "readingTime" "minutes" }}
+          {{ .Scratch.Set "readingTime" "mins" }}
         {{ else }}
-          {{ .Scratch.Set "readingTime" "minute" }}
+          {{ .Scratch.Set "readingTime" "min" }}
         {{ end }}
 
         <span>{{ .ReadingTime }} {{ .Scratch.Get "readingTime" }} read</span>

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -1,32 +1,48 @@
 <div class="info">
-    <h1 class="post-title">
-        <a href="{{ .Permalink }}">{{ .Title }}</a>
-    </h1>
-    {{ if .Date }}
-        <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}" class="post-date">
-            {{ .Date.Format "January 2, 2006" }}
-        </time>
-    {{ end }}
+  <h1 class="post-title">
+    <a href="{{ .Permalink }}">{{ .Title }}</a>
+  </h1>
+
+  <div class="headline">
+    <div>
+      {{ if .Date }}
+      <time datetime="{{ .Date.Format " 2006-01-02T15:04:05Z0700" }}" class="post-date">
+        {{ .Date.Format "January 2, 2006" }}
+      </time>
+      {{ end }}
+      <span> - </span>
+      <span class="reading-time">
+        {{ if gt .ReadingTime 1 }}
+          {{ .Scratch.Set "readingTime" "minutes" }}
+        {{ else }}
+          {{ .Scratch.Set "readingTime" "minute" }}
+        {{ end }}
+
+        <span>{{ .ReadingTime }} {{ .Scratch.Get "readingTime" }} read</span>
+      </span>
+    </div>
+
     {{ if .Params.tags }}
     <ul class="tags">
-        {{ range .Params.tags }}
-        <li class="tag-{{ . }}">
-            <a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a>
-        </li>
-        {{ end }}
+      {{ range .Params.tags }}
+      <li class="tag-{{ . }}">
+        <a href="{{ " tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a>
+      </li>
+      {{ end }}
     </ul>
     {{ end }}
-    
-    {{ $Site := .Site }}
-    {{ if .Params.series }}
-        <p class="seriesname">
-            Series: <a href="{{ $Site.BaseURL }}series/{{ .Params.series | urlize }}">{{ .Params.series }}</a>
-        </p>
-    {{ end }}
-    
-    {{ if .Params.featuredImage }}
-    <p>
-        <img src="{{.Params.featuredImage}}"><br>
-    </p>
-    {{ end }}
+  </div>
+
+  {{ $Site := .Site }}
+  {{ if .Params.series }}
+  <p class="seriesname">
+    Series: <a href="{{ $Site.BaseURL }}series/{{ .Params.series | urlize }}">{{ .Params.series }}</a>
+  </p>
+  {{ end }}
+
+  {{ if .Params.featuredImage }}
+  <p>
+    <img src="{{.Params.featuredImage}}"><br>
+  </p>
+  {{ end }}
 </div>

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -26,7 +26,7 @@
     <ul class="tags">
       {{ range .Params.tags }}
       <li class="tag-{{ . }}">
-        <a href="{{ " tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a>
+        <a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a>
       </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
## Problem
Most of the websites have a reading time element, and it's [recommended](https://tempestamedia.com/2022/12/21/why-its-important-to-add-an-estimated-reading-time/). It also makes the blog look more professional

## Proposal
- Update the `info.html` to include the reading time element and re-organize the HTML to take advantage of Flexbox
- Add CSS classes in `poison.css`

## Demo
- Go to my blog [https://lucasgrocha.com/](https://lucasgrocha.com/)
![image](https://github.com/lukeorth/poison/assets/37275161/c8c3cd31-6701-4a41-be89-2043097bf6b0)


Credits:
- The code to calculate the reading time was shared in this [comment](https://discourse.gohugo.io/t/readingtime-define/13036/4)