### PR TITLE
Fix RSS link (fixes #160 and #157)

### DIFF
--- a/layouts/partials/sidebar/socials.html
+++ b/layouts/partials/sidebar/socials.html
@@ -100,7 +100,7 @@
     </a>
 {{ end }}
 {{ if .Site.Params.rss_icon }}
-    <a target="_blank" class="social" title="RSS Feed" href="{{ .Site.BaseURL }}{{ if .Site.Params.rss_section }}/{{ .Site.Params.rss_section }}{{ end }}/index.xml">
+    <a target="_blank" class="social" title="RSS Feed" href="/{{ if .Site.Params.rss_section }}{{ .Site.Params.rss_section }}{{ end }}/index.xml">
         <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1.2em" viewBox="0 0 1280.000000 1280.000000">
             <g transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)" fill="currentColor">
                 <path d="M2295 11929 c-284 -12 -642 -45 -707 -65 -17 -5 -18 -63 -18 -1039 0 -569 4 -1036 8 -1039 5 -3 74 6 153 19 510 86 1168 95 1789 25 1348 -153 2602 -677 3670 -1531 385 -308 820 -744 1126 -1129 842 -1060 1362 -2313 1514 -3650 70 -621 61 -1279 -25 -1789 -13 -79 -22 -148 -19 -153 3 -4 471 -8 1039 -8 l1035 0 5 23 c51 225 85 942 67 1419 -23 605 -77 1044 -198 1617 -294 1400 -927 2734 -1823 3846 -1043 1295 -2364 2259 -3909 2854 -1158 447 -2451 656 -3707 600z"/>


### PR DESCRIPTION
Correctly render the RSS URL.

Fixes #157 and resolves one use of `BaseURL` as per #160.