### PR TITLE
Fix failed build for pagination

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -91,7 +91,7 @@
 
 <!-- Article Specific Tags -->
 <!-- To make sure this renders only in the article page, we check the section -->
-{{ if eq .Section "posts" }}
+{{ if and (eq .Section "posts") (.Page.IsNode) }}
 <!-- Pagination meta tags for list pages only -->
 {{ $paginator := .Paginate (where .Pages "Type" "posts") }}
 {{ if $paginator }}


### PR DESCRIPTION
It fixes issue #169: Build fails on hugo v0.123: pagination not supported for this page: kind: "page".

See @kLiHz's comment in [AmazingRise/hugo-theme-diary#177](https://github.com/AmazingRise/hugo-theme-diary/issues/177#issuecomment-1962833666).