### PR TITLE
Add author in posts info

### DIFF
--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -5,13 +5,11 @@
 
   <div class="headline">
     <div>
-      {{ if .Params.author }}
-        {{ $author := .Params.author }}
-        {{ $authorURLized := ($author | urlize) }}
-        {{ with .Site.GetPage "author" }}
-          <span><a href="{{ (.GetPage $authorURLized).Permalink }}">{{ $author }}</a> - </span>
+      {{ with .Params.author }}
+        {{ with site.Taxonomies.author.Get . }}
+          <span><a href="{{ .Page.RelPermalink }}">{{ .Page.LinkTitle }}</a> - </span>
         {{ else }}
-          <span>{{ $author }} - </span>
+          <span>{{ . }} - </span>
         {{ end }}
       {{ end }}
       {{ if .Date }}

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -6,10 +6,12 @@
   <div class="headline">
     <div>
       {{ if .Params.author }}
-        {{ if .Site.Taxonomies.author }}
-          <span><a href="{{ .Site.BaseURL }}author/{{ .Params.author | urlize }}">{{ .Params.author }}</a> - </span>
+        {{ $author := .Params.author }}
+        {{ $authorURLized := ($author | urlize) }}
+        {{ with .Site.GetPage "author" }}
+          <span><a href="{{ (.GetPage $authorURLized).Permalink }}">{{ $author }}</a> - </span>
         {{ else }}
-          <span>{{ .Params.author }} - </span>
+          <span>{{ $author }} - </span>
         {{ end }}
       {{ end }}
       {{ if .Date }}

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -5,6 +5,9 @@
 
   <div class="headline">
     <div>
+      {{ if .Params.author }}
+          <a href="{{ .Site.BaseURL }}author/{{ .Params.author | urlize }}">{{ .Params.author }}</a> - 
+      {{ end }}
       {{ if .Date }}
       <time datetime="{{ .Date.Format " 2006-01-02T15:04:05Z0700" }}" class="post-date">
         {{ .Date.Format "January 2, 2006" }}

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -6,7 +6,11 @@
   <div class="headline">
     <div>
       {{ if .Params.author }}
-          <a href="{{ .Site.BaseURL }}author/{{ .Params.author | urlize }}">{{ .Params.author }}</a> - 
+        {{ if .Site.Taxonomies.author }}
+          <span><a href="{{ .Site.BaseURL }}author/{{ .Params.author | urlize }}">{{ .Params.author }}</a> - </span>
+        {{ else }}
+          <span>{{ .Params.author }} - </span>
+        {{ end }}
       {{ end }}
       {{ if .Date }}
       <time datetime="{{ .Date.Format " 2006-01-02T15:04:05Z0700" }}" class="post-date">


### PR DESCRIPTION
closes #170 

## Description
As discussed in the issue, if `author` is in the article's metadata add it just before the date in the post's info  
Moreover, if `author` is a taxonomy for the website make it an hyperlink to `/author/<author name>` 

## What could be improved
Currently no CSS is added, and while the result seems good enough in dark mode with the hyperlink (see #170)   
without the hyperlink it can be a bit "poor"
![Screenshot_20240324_195802](https://github.com/lukeorth/poison/assets/79016298/47315da0-ca0e-4279-87e5-5d57f78a5fcf)
I'd like to give it its own style, like tags but I'm not very creative when it comes to GUI...

~~Also, when listing an author's post, I believe `layouts/_default/list.html` is used to list terms of a taxonomy if I trust [the doc](https://gohugo.io/templates/lists/#list-defaults). But it "titlized" the taxonomy's term (here my nickname) thus not respecting the case:
![Screenshot_20240324_201302](https://github.com/lukeorth/poison/assets/79016298/f746931d-2d4a-40d9-988b-ec0967ab6e44)
`Ctmbl` instead of `ctmbl`  
this is basically the same issue that https://github.com/lukeorth/poison/issues/152, also https://discourse.gohugo.io/t/taxonomy-terms-permalink-spaces-vs-dashes/48629/5 might help~~  
Forget that I noticed that hugo 0.123.0 introduced `capitalizelisttitles = false` that address my issue

Finally it's a bit outside of the scope of this PR but it might be nice to add a guard for tags URLs, as I did for author, if `tags` is not a taxonomy for the website