### PR TITLE
Safeguard meta.html fileExists for error-free build on Windows 

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -31,20 +31,20 @@
   {{ $image_ext := trim (path.Ext $image_path | lower) "." -}}
   {{ if fileExists $image_path_local -}} 
     {{ $image_path:= resources.Get $image_path}}
-      <meta property="og:image" content="{{ $image_path.RelPermalink }}" />
-      {{/* If not SVG, read image aspect ratio and define Twitter Card and Open Graph width and height  */ -}}
-      {{ if ne $image_ext "svg" -}}
-        {{ with (imageConfig $image_path_local) -}}
+    <meta property="og:image" content="{{ $image_path.RelPermalink }}" />
+    {{/* If not SVG, read image aspect ratio and define Twitter Card and Open Graph width and height  */ -}}
+    {{ if ne $image_ext "svg" -}}
+      {{ with (imageConfig $image_path_local) -}}
         {{ if (and (gt .Width 144) (gt .Height 144)) -}}
           <meta name="twitter:image" content="{{ $image_path.RelPermalink }}"/>
           <meta name="twitter:card" content="summary{{ if (and (gt .Width 300) (gt .Height 157) (not (eq .Width .Height))) }}_large_image{{ end }}">
         {{ end -}}
         <meta property="og:image:width" content="{{ .Width }}">
         <meta property="og:image:height" content="{{ .Height }}">
-        {{ end -}}
       {{ end -}}
-      <meta property="og:image:type" content="image/{{ if eq $image_ext `svg` }}svg+xml{{ else }}{{ replaceRE `^jpg$` `jpeg` $image_ext }}{{ end }}">
     {{ end -}}
+    <meta property="og:image:type" content="image/{{ if eq $image_ext `svg` }}svg+xml{{ else }}{{ replaceRE `^jpg$` `jpeg` $image_ext }}{{ end }}">
+  {{ end -}}
 {{ end -}}
 
 <!-- Title Tags -->

--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -26,23 +26,25 @@
 
 {{ "<!-- Open Graph image and Twitter Card metadata -->" | safeHTML }}
 {{ $image_path := .Params.image | default .Site.Params.og_image -}}
-{{ $image_path_local :=  printf "assets/%s" $image_path -}}
-{{ $image_ext := trim (path.Ext $image_path | lower) "." -}}
-{{ if fileExists $image_path_local -}}
-{{ $image_path:= resources.Get $image_path}}
-  <meta property="og:image" content="{{ $image_path.RelPermalink }}" />
-  {{/* If not SVG, read image aspect ratio and define Twitter Card and Open Graph width and height  */ -}}
-  {{ if ne $image_ext "svg" -}}
-    {{ with (imageConfig $image_path_local) -}}
-    {{ if (and (gt .Width 144) (gt .Height 144)) -}}
-      <meta name="twitter:image" content="{{ $image_path.RelPermalink }}"/>
-      <meta name="twitter:card" content="summary{{ if (and (gt .Width 300) (gt .Height 157) (not (eq .Width .Height))) }}_large_image{{ end }}">
+{{ with $image_path }}
+  {{ $image_path_local :=  printf "assets/%s" $image_path -}}
+  {{ $image_ext := trim (path.Ext $image_path | lower) "." -}}
+  {{ if fileExists $image_path_local -}} 
+    {{ $image_path:= resources.Get $image_path}}
+      <meta property="og:image" content="{{ $image_path.RelPermalink }}" />
+      {{/* If not SVG, read image aspect ratio and define Twitter Card and Open Graph width and height  */ -}}
+      {{ if ne $image_ext "svg" -}}
+        {{ with (imageConfig $image_path_local) -}}
+        {{ if (and (gt .Width 144) (gt .Height 144)) -}}
+          <meta name="twitter:image" content="{{ $image_path.RelPermalink }}"/>
+          <meta name="twitter:card" content="summary{{ if (and (gt .Width 300) (gt .Height 157) (not (eq .Width .Height))) }}_large_image{{ end }}">
+        {{ end -}}
+        <meta property="og:image:width" content="{{ .Width }}">
+        <meta property="og:image:height" content="{{ .Height }}">
+        {{ end -}}
+      {{ end -}}
+      <meta property="og:image:type" content="image/{{ if eq $image_ext `svg` }}svg+xml{{ else }}{{ replaceRE `^jpg$` `jpeg` $image_ext }}{{ end }}">
     {{ end -}}
-    <meta property="og:image:width" content="{{ .Width }}">
-    <meta property="og:image:height" content="{{ .Height }}">
-    {{ end -}}
-  {{ end -}}
-  <meta property="og:image:type" content="image/{{ if eq $image_ext `svg` }}svg+xml{{ else }}{{ replaceRE `^jpg$` `jpeg` $image_ext }}{{ end }}">
 {{ end -}}
 
 <!-- Title Tags -->


### PR DESCRIPTION
closes #166.

Thanks for an amazing theme! This PR introduces a simple nil check with `{{ with $image_path }}` in _meta.html_ before the call to `fileExists $image_path_local`.

This change fixes the build issues on Windows machines as described in #166 and #148, as the build will no longer reach a `fileExists` call with a `"\assets\%!s(<nil>)"` argument, which is not a supported file path on Windows due to the percent sign.