### PR TITLE
feat: Add collapsable details shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ You can embed rendered PlantUML diagrams.
 
 For an example of how to do this, please visit the [Poison demo site](https://poison.lukeorth.com/posts/introducing-poison/#plantuml-diagrams);
 
+### Details
+
+Embed details in your pages, as follows:
+
+```
+{{< details summary="A summary" >}}
+Markdown content
+{{< /details >}}
+```
+
+
 ## Installation
 
 First, clone this repository into your `themes` directory:

--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,0 +1,7 @@
+{{ $body := .Inner }}
+{{ $summary := .Get "summary" }}
+
+<details>
+    <summary>{{ $summary  | safeHTML }}</summary>
+   {{ $body | markdownify }}
+</details>


### PR DESCRIPTION
This commit adds a shortcode for collapsable markdown items.

```
{{< details summary="A summary" >}}
Markdown content
{{< /details >}}
```


