### PR TITLE
Fix series URL

### DIFF
--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -13,7 +13,7 @@
         {{ end }}
       {{ end }}
       {{ if .Date }}
-      <time datetime="{{ .Date.Format " 2006-01-02T15:04:05Z0700" }}" class="post-date">
+      <time datetime='{{ .Date.Format " 2006-01-02T15:04:05Z0700" }}' class="post-date">
         {{ .Date.Format "January 2, 2006" }}
       </time>
       {{ end }}
@@ -33,7 +33,7 @@
     <ul class="tags">
       {{ range .Params.tags }}
       <li class="tag-{{ . }}">
-        <a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a>
+        <a href='{{ "tags/" | absLangURL }}{{ . | urlize }}'>{{ . }}</a>
       </li>
       {{ end }}
     </ul>

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -40,11 +40,12 @@
     {{ end }}
   </div>
 
-  {{ $Site := .Site }}
-  {{ if .Params.series }}
-  <p class="seriesname">
-    Series: <a href="{{ $Site.BaseURL }}series/{{ .Params.series | urlize }}">{{ .Params.series }}</a>
-  </p>
+  {{ with .Params.series }}
+    {{ with site.Taxonomies.series.Get . }}
+      <p class="seriesname">
+        Series: <a href="{{ .Page.RelPermalink }}">{{ .Page.LinkTitle }}</a>
+      </p>
+    {{ end }}
   {{ end }}
 
   {{ if .Params.featuredImage }}


### PR DESCRIPTION
A fix for the issue I mentioned in #173 

> But in the case of series the baseURL is simply prefixed to the relative path, which isn't robust, for example if baseURL doesn't finish with a / (it is my case and it breaks, try clicking on the series at https://iscsc.fr/posts/introducing-poison/): if baseURL=http://example.com it will built the URL http://example.comseries/my-series which of course will fail.

And a minor fix for a syntax highlight issue caused by conflicting quotes:
before the fix:
![syntax highlight before](https://github.com/user-attachments/assets/334cfe5b-cc7c-433a-8d58-370b995a8d28)
after the fix:
![syntax highlight after](https://github.com/user-attachments/assets/57ab6663-b6ab-4d84-a52b-21de069404c8)
