### PR TITLE
fixed DisqusShortname breaking issue

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
     {{ partial "post/listmonk_email_newsletters.html" . }}
   {{ end }}
   {{ partial "post/navigation.html" . }}
-  {{ if or (.Site.Params.remark42) (.Site.DisqusShortname) }}
+  {{ if or (.Site.Params.remark42) (.Site.Config.Services.Disqus.Shortname) }}
     {{ partial "post/comments.html" . }}
   {{ end }}
 </div>

--- a/layouts/partials/post/comments.html
+++ b/layouts/partials/post/comments.html
@@ -14,7 +14,7 @@
             }
         </script>
         <script>!function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)}}(remark_config.components||["embed"],document);</script>
-    {{ else if .Site.DisqusShortname }}
+    {{ else if .Site.Config.Services.Disqus.Shortname }}
         {{ template "_internal/disqus.html" . }}
     {{ end }}
 </div>


### PR DESCRIPTION
Changes reflect the new requirements of Hugo and get rid of the following error:

`ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.Disqus.Shortname instead.`