### PR TITLE
Use linkTitle instead of title in menu to allow for short menue titles

### DIFF
--- a/layouts/partials/sidebar/menu.html
+++ b/layouts/partials/sidebar/menu.html
@@ -25,7 +25,7 @@
                         </li>
                         {{ range (first $menu_item.Limit .Pages) }}
                             <li class="bullet">
-                                <a href="{{ .Permalink }}">{{ .Title }}</a>
+                                <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
                             </li>
                         {{ end }}
                     {{ end }}


### PR DESCRIPTION
With this change, it is possible to use `linkTitle` in the front matter to define shorter titles shown in the page menu.

Example:
```
title: "My super extra very long title"
linkTitle "Long Title ..."
```
`linkTitle` defaults to `title` if it is not set.
