### PR TITLE
Hide comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Once everything is set up, you can activate it in the *Poison* theme by includin
     remark42_site_id = "your_site_id"
 ```
 
+You can disable the comments section on specific posts using the `hideComments: true` parameter. Simply add this line to the front matter of the desired post.
+
+```yaml
+---
+title: "Example to demonstrate how to hide comments on a single post"
+date: 2024-12-07
+draft: false
+tags: ["Hugo"]
+hideComments: true
+---
+```
+
 ### Analytics
 
 Gain insights on your users.  Poison currently supports [Plausible](https://plausible.io) which is available via a paid service or by [self-hosting](https://github.com/plausible/analytics).  Take a look at the Poison demo site's 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
     {{ partial "post/listmonk_email_newsletters.html" . }}
   {{ end }}
   {{ partial "post/navigation.html" . }}
-  {{ if or (.Site.Params.remark42) (.Site.Config.Services.Disqus.Shortname) }}
+  {{ if and (not .Params.hideComments) (or .Site.Params.remark42 .Site.Config.Services.Disqus.Shortname) }}
     {{ partial "post/comments.html" . }}
   {{ end }}
 </div>


### PR DESCRIPTION
This pull request introduces changes to the Poison theme to enable the ability to hide the comments section on specific posts.

### Motivation

The primary motivation for this change is to allow greater flexibility in content presentation, particularly for posts like a resume, where displaying a comments section may not be appropriate.


### Key Changes

1. **Documentation Updates**

- Added instructions on how to disable the comments section for specific posts by using the hideComments: true parameter in the front matter.

2. **Template File Modification**

- Updated the template logic to check for the hideComments parameter and conditionally disable the comments section when it is set to true.