### PR TITLE
✨ Add page param for disabling reading time

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you prefer not to display a table of contents, you can disable them site-wide
     hideToc: true
 ```
 
-Alternatively, you can choose to disable the table of contents on a per-post basis by putting the flag in the frontmatter of an individual post.
+Alternatively, you can choose to disable the table of contents on a per-post basis by putting the flag in the front matter of an individual post.
 
 ```yaml
 ---
@@ -81,7 +81,7 @@ Facilitate discourse by allowing users to comment on your posts.  *Poison* curre
 
 **Note**: *Enabling comments will add external dependencies.*
 
-- [Disqus Demo Site](https://about.disqus.com/disqus-demo-page) 
+- [Disqus Demo Site](https://about.disqus.com/disqus-demo-page)
 - [Remark42 Demo Site](https://remark42.com/demo/)
 
 ***Disqus*** is free and easy to use.  Checkout the [Hugo docs](https://gohugo.io/content-management/comments/) to get started.  Once you've created a *Disqus* account, you can activate it in the *Poison* theme by adding a single line to your `config.toml` file.
@@ -107,7 +107,7 @@ Once everything is set up, you can activate it in the *Poison* theme by includin
 
 ### Analytics
 
-Gain insights on your users.  Poison currently supports [Plausible](https://plausible.io) which is available via a paid service or by [self-hosting](https://github.com/plausible/analytics).  Take a look at the Poison demo site's 
+Gain insights on your users.  Poison currently supports [Plausible](https://plausible.io) which is available via a paid service or by [self-hosting](https://github.com/plausible/analytics).  Take a look at the Poison demo site's
 
 **Note**: *Enabling analytics will add external dependencies.*
 
@@ -130,10 +130,10 @@ For reference, the configuration above would add the following code to each page
 
 ### Email newsletters
 
-Allow users to subscribe to your blog newsletters via email. 
+Allow users to subscribe to your blog newsletters via email.
 Poison currently supports [Listmonk](https://listmonk.app/) which is available via [self-hosting](https://github.com/knadh/listmonk).
 Listmonk is a standalone, self-hosted, newsletter and mailing list manager.
-The downside is that you must host it yourself. 
+The downside is that you must host it yourself.
 Checkout the Listmonk [documentation](https://listmonk.app/docs/) to get started.
 
 Once you've established your Listmonk instance, activate it by adding these lines to your ```config.toml``` file.
@@ -148,13 +148,13 @@ Once you've established your Listmonk instance, activate it by adding these line
     listmonk_subscription_error_message = "Something went wrong"          # default: Sorry, something went wrong. Please, try again
 ```
 
-This will insert a form at the bottom of each post's content. 
+This will insert a form at the bottom of each post's content.
 The user will be subscribed to the newsletter specified in the ``listmonk_subscription_list_uiid`` parameter.
 
 ### Series
 Sensibly link and display content into "series" (i.e. *Tutorial One*, *Tutorial Two*, etc.).
 
-This is done with a custom taxonomy, so just add `series` to the frontmatter on the content you'd like to group together.
+This is done with a custom taxonomy, so just add `series` to the front matter on the content you'd like to group together.
 
 ```yaml
 ---
@@ -170,13 +170,13 @@ tags: ["Hugo"]
 Make your mathematical notations pop.
 
 For notations that should appear on their own line, use the block quotes `$$ ... $$`
-    
+
 $$ 5 \times 5 = 25 $$
 
 For notations that should appear on the same line, use the inline quotes `$ ... $`
 
 **Note**: *Enabling KaTeX will add external dependencies.*
-    
+
 ### Tabs
 Some content is just better viewed in tabs.  Luckily we have a shortcode for that.
 <p float="left">
@@ -201,9 +201,9 @@ This is a code block.
 
 {{</* /tabs */>}}
 ```
- 
+
 ### Mermaid diagrams
-You can embed rendered Mermaid diagrams.  
+You can embed rendered Mermaid diagrams.
 
 **Note**: *Enabling Mermaid diagrams will add external dependencies.*
 
@@ -212,7 +212,7 @@ You can embed rendered Mermaid diagrams.
 For an example of how to do this, please visit the [Poison demo site](https://poison.lukeorth.com/posts/introducing-poison/#mermaid-diagrams).
 
 ### PlantUML diagrams
-You can embed rendered PlantUML diagrams.  
+You can embed rendered PlantUML diagrams.
 
 **Note**: *Enabling PlantUML diagrams will add external dependencies.*
 
@@ -287,13 +287,13 @@ menu = [
             # Limit:        If the files should be listed, how many should be shown.
 
         # SINGLE PAGE
-        # Note that you must put your markdown file 
+        # Note that you must put your markdown file
         # inside of a directory with the same name.
 
         # Example:
         # ... /content/about/about.md
         {Name = "About", URL = "/about/", HasChildren = false},
-        
+
         # ... /content/foo/_index.md
         # {Name = "Foo", URL = "/foo/", HasChildren = false},
 
@@ -316,6 +316,21 @@ When visiting the base url for the site, i.e. `your.domain.com/`, a paginated fe
 ```toml
 [params]
   front_page_content = ["posts", "projects"]
+```
+
+### Front matter
+
+You can disable the reading time indicator on a page by adding `disableReadingTime = true` to the page params in the front matter.
+
+For example:
+```toml
++++
+date = '2024-11-02'
+draft = true
+title = 'Foo'
+[params]
+  disableReadingTime = true
++++
 ```
 
 ### Example config
@@ -354,7 +369,7 @@ pluralizelisttitles = false   # removes the automatically appended "s" on sideba
         {Name = "Posts", URL = "/posts/", Pre = "Recent", HasChildren = true, Limit = 5},
     ]
 
-    # Links to your socials.  Comment or delete any you don't need/use. 
+    # Links to your socials.  Comment or delete any you don't need/use.
     discord_url = "https://discord.com"
     email_url = "mailto://user@domain"
     facebook_url = "https://facebook.com"

--- a/layouts/partials/post/info.html
+++ b/layouts/partials/post/info.html
@@ -17,6 +17,7 @@
         {{ .Date.Format "January 2, 2006" }}
       </time>
       {{ end }}
+      {{ if not .Params.disableReadingTime }}
       <span> - </span>
       <span class="reading-time">
         {{ if gt .ReadingTime 1 }}
@@ -27,6 +28,7 @@
 
         <span>{{ .ReadingTime }} {{ .Scratch.Get "readingTime" }} read</span>
       </span>
+      {{ end }}
     </div>
 
     {{ if .Params.tags }}


### PR DESCRIPTION
This PR introduces a new page parameter `disableReadingTime` which can be set to `true` to disable the reading time indicator for posts.

| `disableReadingTime = false` (default) | `disableReadingTime = true`
| - | - |
| ![grafik](https://github.com/user-attachments/assets/40f3237c-2b56-4362-8ad1-0a6abc6b5415) | ![grafik](https://github.com/user-attachments/assets/3bd34714-3c97-4371-9bd4-0e91ae01e623) |
